### PR TITLE
Replace copy-on-grow with seal-and-chain in PooledBufferWriter&lt;T&gt;

### DIFF
--- a/TestProjects/LaquaiLib.UnitTests/IO/PooledBufferWriterTests.cs
+++ b/TestProjects/LaquaiLib.UnitTests/IO/PooledBufferWriterTests.cs
@@ -323,21 +323,21 @@ public class PooledBufferWriterTests
     }
 
     [Fact]
-    public void GetSegmentsEnumeratesEveryRentedSegment()
+    public void GetSegmentsEnumeratesEverySegmentTrimmedToItsWrittenLength()
     {
         using var writer = new PooledBufferWriter<byte>();
-        writer.Advance(writer.GetSpan().Length);
-        writer.Advance(writer.GetSpan().Length);
+        var first = writer.GetSpan().Length;
+        writer.Advance(first);
+        var second = writer.GetSpan().Length;
+        writer.Advance(second);
         writer.GetSpan();
 
-        var count = 0;
+        var lengths = new List<int>();
         var enumerator = writer.GetSegments();
         while (enumerator.MoveNext())
-        {
-            Assert.False(enumerator.Current.IsEmpty);
-            count++;
-        }
-        Assert.Equal(3, count);
+            lengths.Add(enumerator.Current.Length);
+
+        Assert.Equal(new[] { first, second, 0 }, lengths);
     }
 
     [Fact]
@@ -519,5 +519,179 @@ public class PooledBufferWriterTests
         var span = writer.GetSpan(10000);
         Assert.True(span.Length >= 10000);
         Assert.Single(pool.RentRequests);
+    }
+
+    [Fact]
+    public void OversizedSizeHintChainsANewSegmentWithoutReturningTheOldOne()
+    {
+        var pool = new TrackingArrayPool<byte>();
+        using var writer = new PooledBufferWriter<byte>(pool);
+        var first = writer.GetSpan();
+        first[0] = 1;
+        first[1] = 2;
+        writer.Advance(2);
+
+        var wide = writer.GetSpan(8192);
+        Assert.True(wide.Length >= 8192);
+        Assert.Equal(2, pool.RentRequests.Count);
+        Assert.Empty(pool.Returns);
+
+        wide[0] = 3;
+        writer.Advance(1);
+        Assert.Equal(3L, writer.AbsoluteLength);
+        Assert.Equal(new byte[] { 1, 2, 3 }, writer.ToArray());
+    }
+
+    [Fact]
+    public void OversizedSizeHintMovesPositionToANewSegment()
+    {
+        using var writer = new PooledBufferWriter<byte>();
+        writer.GetSpan();
+        writer.Advance(1);
+        writer.GetSpan(8192);
+        var position = writer.Position;
+        Assert.Equal(1, position.SegmentIndex);
+        Assert.Equal(0, position.Offset);
+        Assert.Equal(1L, writer.AbsoluteLength);
+    }
+
+    [Fact]
+    public void WritesAcrossManySegmentsWithVaryingHintsRoundTrip()
+    {
+        using var writer = new PooledBufferWriter<byte>();
+        var expected = new List<byte>();
+        byte value = 0;
+        foreach (var hint in new[] { 1, 700, 2048, 3, 5000, 64, 1, 9000, 300 })
+        {
+            var span = writer.GetSpan(hint);
+            Assert.True(span.Length >= hint);
+            for (var i = 0; i < hint; i++)
+            {
+                span[i] = value;
+                expected.Add(value);
+                value++;
+            }
+            writer.Advance(hint);
+        }
+
+        Assert.Equal(expected.Count, writer.AbsoluteLength);
+        Assert.Equal(expected.ToArray(), writer.ToArray());
+    }
+
+    [Fact]
+    public void SetLengthRewindsIntoAPartiallyFilledSealedSegment()
+    {
+        using var writer = new PooledBufferWriter<byte>();
+        var first = writer.GetSpan();
+        first[0] = 1;
+        first[1] = 2;
+        first[2] = 3;
+        writer.Advance(3);
+
+        var wide = writer.GetSpan(8192);
+        wide[0] = 4;
+        wide[1] = 5;
+        writer.Advance(2);
+        Assert.Equal(5L, writer.AbsoluteLength);
+
+        writer.SetLength(2);
+        Assert.Equal(2L, writer.AbsoluteLength);
+        Assert.Equal(new byte[] { 1, 2 }, writer.ToArray());
+
+        var resumed = writer.GetSpan(4);
+        resumed[0] = 9;
+        resumed[1] = 8;
+        resumed[2] = 7;
+        resumed[3] = 6;
+        writer.Advance(4);
+        Assert.Equal(6L, writer.AbsoluteLength);
+        Assert.Equal(new byte[] { 1, 2, 9, 8, 7, 6 }, writer.ToArray());
+    }
+
+    [Fact]
+    public void GetSegmentsAfterRewindStopsAtTheWritePosition()
+    {
+        using var writer = new PooledBufferWriter<byte>();
+        writer.GetSpan().Fill(1);
+        writer.Advance(4);
+        writer.GetSpan(8192)[0] = 2;
+        writer.Advance(1);
+        writer.SetLength(2);
+
+        var count = 0;
+        var enumerator = writer.GetSegments();
+        while (enumerator.MoveNext())
+        {
+            Assert.Equal(2, enumerator.Current.Length);
+            count++;
+        }
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void ClearAfterSealingResetsToTheFirstSegment()
+    {
+        using var writer = new PooledBufferWriter<byte>();
+        writer.GetSpan()[0] = 1;
+        writer.Advance(1);
+        writer.GetSpan(8192)[0] = 2;
+        writer.Advance(1);
+        writer.Clear();
+
+        Assert.Equal(0L, writer.AbsoluteLength);
+        Assert.Empty(writer.ToArray());
+
+        writer.GetSpan(3)[0] = 7;
+        writer.Advance(1);
+        Assert.Equal(new byte[] { 7 }, writer.ToArray());
+    }
+
+    [Fact]
+    public void ReusableSegmentLargeEnoughForTheRequestIsNotReRented()
+    {
+        var pool = new TrackingArrayPool<byte>();
+        using var writer = new PooledBufferWriter<byte>(pool);
+        writer.Advance(writer.GetSpan().Length);
+        writer.Advance(writer.GetSpan().Length);
+        writer.SetLength(1);
+        writer.Advance(writer.GetSpan().Length);
+        writer.GetSpan();
+
+        Assert.Equal(2, pool.RentRequests.Count);
+        Assert.Empty(pool.Returns);
+    }
+
+    [Fact]
+    public void ReusableSegmentTooSmallForTheRequestIsReturnedAndReplaced()
+    {
+        var pool = new TrackingArrayPool<byte>();
+        using var writer = new PooledBufferWriter<byte>(pool);
+        writer.Advance(writer.GetSpan().Length);
+        writer.GetSpan();
+        writer.Advance(2);
+        writer.SetLength(1);
+        Assert.Empty(pool.Returns);
+
+        var span = writer.GetSpan(9000);
+        Assert.True(span.Length >= 9000);
+        Assert.Equal(3, pool.RentRequests.Count);
+        Assert.Single(pool.Returns);
+    }
+
+    [Fact]
+    public void DisposeReturnsEverySegmentExactlyOnceAfterSealing()
+    {
+        var pool = new TrackingArrayPool<byte>();
+        var writer = new PooledBufferWriter<byte>(pool);
+        writer.GetSpan();
+        writer.Advance(1);
+        writer.GetSpan(4096);
+        writer.Advance(1);
+        writer.GetSpan(9000);
+        writer.Advance(1);
+        writer.Dispose();
+
+        Assert.Equal(3, pool.Returns.Count);
+        Assert.Equal(3, pool.Returns.Select(static entry => entry.Array).Distinct().Count());
     }
 }

--- a/multitarget/LaquaiLib/IO/BufferWriter.cs
+++ b/multitarget/LaquaiLib/IO/BufferWriter.cs
@@ -134,6 +134,9 @@ public abstract class ContiguousBufferWriterBase<T> : BufferWriterBase<T>
 /// Implements <see cref="BufferWriterBase{T}"/> that grows by renting segments from an <see cref="ArrayPool{T}"/>.
 /// </summary>
 /// <typeparam name="T">The type of elements written to the buffer.</typeparam>
+/// <remarks>
+/// A request the current segment cannot satisfy seals that segment where it stands and chains a new one behind it, so data that has already been written is never copied. A sealed segment may therefore retain an unused tail, which means the total rented capacity can exceed <see cref="SegmentedBufferWriterBase{T}.AbsoluteLength"/>.
+/// </remarks>
 public sealed class PooledBufferWriter<T>(ArrayPool<T> pool = null, bool zeroOnDispose = false) : SegmentedBufferWriterBase<T>
 {
     /// <summary>
@@ -142,18 +145,22 @@ public sealed class PooledBufferWriter<T>(ArrayPool<T> pool = null, bool zeroOnD
     public struct SegmentEnumerator : IEnumerator<Memory<T>>
     {
         private readonly List<T[]> _segments;
-        private int _state;
-        private List<T[]>.Enumerator _inner;
+        private readonly List<int> _lengths;
+        private readonly int _count;
+        private int _i;
 
-        internal SegmentEnumerator(List<T[]> segments)
+        internal SegmentEnumerator(List<T[]> segments, List<int> lengths, int count)
         {
             _segments = segments;
+            _lengths = lengths;
+            _count = count;
+            _i = -1;
         }
 
         /// <summary>
-        /// Gets the current segment of the buffer as a <see cref="Memory{T}"/> instance.
+        /// Gets the current segment of the buffer as a <see cref="Memory{T}"/> instance. Only the written portion of the segment is exposed; the unused tail a sealed segment may carry is never visible.
         /// </summary>
-        public readonly Memory<T> Current => _inner.Current;
+        public readonly Memory<T> Current => _segments[_i].AsMemory(0, _lengths[_i]);
 
         /// <summary>
         /// Advances the enumerator to the next segment of the buffer.
@@ -161,31 +168,21 @@ public sealed class PooledBufferWriter<T>(ArrayPool<T> pool = null, bool zeroOnD
         /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next segment; <see langword="false"/> if the enumerator has passed the end of the buffer.</returns>
         public bool MoveNext()
         {
-            if (_state == 2)
+            if (_i >= _count)
                 return false;
-            if (_state == 0)
-                Reset();
-            if (_inner.MoveNext())
-                return true;
-            _state = 2;
-            return false;
+            return ++_i < _count;
         }
         /// <summary>
         /// Resets the enumerator to its initial position, which is before the first segment of the buffer.
         /// </summary>
-        public void Reset()
-        {
-            _inner.Dispose();
-            _inner = _segments.GetEnumerator();
-            _state = 1;
-        }
+        public void Reset() => _i = -1;
 
         readonly object IEnumerator.Current => Current;
 
         /// <summary>
         /// Disposes the enumerator and releases any resources associated with it.
         /// </summary>
-        public readonly void Dispose() => _inner.Dispose();
+        public readonly void Dispose() { }
     }
 
     private const int DefaultSegmentSize = 2048;
@@ -196,10 +193,14 @@ public sealed class PooledBufferWriter<T>(ArrayPool<T> pool = null, bool zeroOnD
     private readonly ArrayPool<T> _pool = pool ?? ArrayPool<T>.Shared;
     private readonly bool _zeroOnDispose = zeroOnDispose;
     private readonly List<T[]> _segments = [];
+    // the number of elements actually written to each segment, index-aligned with _segments; entries for segments before the current one are authoritative, the entry for the current segment is stale until it is sealed or explicitly flushed from index
+    private readonly List<int> _lengths = [];
+    // the sum of _lengths[0..segment-1]; maintained incrementally so AbsoluteLength stays O(1) instead of walking the chain
+    private long _priorLength;
     private bool _disposed;
 
     /// <inheritdoc/>
-    public override long AbsoluteLength => segment < 0 ? 0 : SegmentedBufferHelpers.RelativeToAbsolute(CollectionsMarshal.AsSpan(_segments), segment, index);
+    public override long AbsoluteLength => segment < 0 ? 0 : _priorLength + index;
 
     /// <inheritdoc/>
     public override Memory<T> GetMemory(int sizeHint = 0)
@@ -209,36 +210,45 @@ public sealed class PooledBufferWriter<T>(ArrayPool<T> pool = null, bool zeroOnD
         return Next(sizeHint)[index..];
     }
     /// <inheritdoc/>
+    // seal-and-chain, like the writer inside System.IO.Pipelines.Pipe: a segment that cannot satisfy the request is sealed where it stands and a new one is chained behind it, so committed data is never copied. The price is the unused tail a sealed segment keeps, which is far cheaper than an O(n) copy.
     protected sealed override Memory<T> Next(int sizeHint = 0)
     {
         var need = sizeHint > 0 ? sizeHint : 1;
 
-        // currentSegment isn't full, so advancing would violate contiguity of the data we receive
-        if (!currentSegment.IsEmpty && index != currentSegment.Length)
-            return currentSegment.Length - index >= need ? currentSegment : (currentSegment = Grow(checked(index + need)));
+        if (!currentSegment.IsEmpty && currentSegment.Length - index >= need)
+            return currentSegment;
+
+        if (segment >= 0)
+        {
+            // seal: index is the real written length, whatever capacity follows it is abandoned (but still owned, so Dispose returns it)
+            _lengths[segment] = index;
+            _priorLength += index;
+        }
 
         index = 0;
         segment++;
 
-        if (segment < _segments.Count)
+        if (segment < _segments.Count && _segments[segment].Length >= need)
         {
-            // we already had a segment and got SetLength'd toward the front, so just reuse it
-            return currentSegment = _segments[segment].Length >= need ? _segments[segment] : Grow(need);
+            // we got SetLength'd toward the front and walked back out to a segment we already own, so just reuse it
+            _lengths[segment] = 0;
+            return currentSegment = _segments[segment];
         }
 
         var arr = _pool.Rent(int.Max(need, _maxElems));
-        _segments.Add(arr);
+        if (segment < _segments.Count)
+        {
+            // the segment we own here is too small for the request; its contents are past the write position and therefore already discarded
+            _pool.Return(_segments[segment], _zeroOnDispose);
+            _segments[segment] = arr;
+            _lengths[segment] = 0;
+        }
+        else
+        {
+            _segments.Add(arr);
+            _lengths.Add(0);
+        }
         return currentSegment = arr;
-    }
-    // segments before the current one must stay completely full, so an oversized sizeHint replaces the current segment rather than skipping to a new one
-    private T[] Grow(int minimumLength)
-    {
-        var old = _segments[segment];
-        var arr = _pool.Rent(int.Max(minimumLength, _maxElems));
-        old.AsSpan(0, index).CopyTo(arr);
-        _segments[segment] = arr;
-        _pool.Return(old, _zeroOnDispose);
-        return arr;
     }
     /// <inheritdoc/>
     public override void SetLength(long length)
@@ -246,17 +256,29 @@ public sealed class PooledBufferWriter<T>(ArrayPool<T> pool = null, bool zeroOnD
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentOutOfRangeException.ThrowIfNegative(length);
 
+        if (segment >= 0)
+            _lengths[segment] = index;
+
         var current = AbsoluteLength;
         if (length > current)
             throw new ArgumentOutOfRangeException(nameof(length), $"Cannot set length beyond the current absolute length of the buffer. Use {nameof(Advance)}.");
         if (length == current)
             return;
 
-        var (idx, off) = SegmentedBufferHelpers.AbsoluteToRelative(CollectionsMarshal.AsSpan(_segments), length);
+        // segments are no longer guaranteed to be packed, so the walk has to consult the written lengths rather than the rented capacities. length < current bounds this to idx <= segment, so the indexing below is always in range.
+        var remaining = length;
+        var idx = 0;
+        while (idx < _lengths.Count && remaining > _lengths[idx])
+        {
+            remaining -= _lengths[idx];
+            idx++;
+        }
+
         segment = idx;
-        index = off;
+        index = (int)remaining;
         // without this, subsequent writes would land in whatever segment happened to be current before the rewind
         currentSegment = _segments[idx];
+        _priorLength = length - remaining;
     }
     /// <inheritdoc/>
     public override void Clear(bool zero = false)
@@ -272,10 +294,15 @@ public sealed class PooledBufferWriter<T>(ArrayPool<T> pool = null, bool zeroOnD
     /// Gets an enumerator that iterates through the segments of the buffer as <see cref="Memory{T}"/> instances.
     /// </summary>
     /// <returns>The enumerator for the segments of the buffer.</returns>
+    /// <remarks>
+    /// Each segment is exposed trimmed to the number of elements written to it, and enumeration stops at the segment holding the write position. Segments that exist only because the buffer was previously longer are not enumerated.
+    /// </remarks>
     public SegmentEnumerator GetSegments()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-        return new(_segments);
+        if (segment >= 0)
+            _lengths[segment] = index;
+        return new(_segments, _lengths, segment + 1);
     }
     /// <summary>
     /// Copies the data written so far to a new array and returns it.
@@ -284,13 +311,15 @@ public sealed class PooledBufferWriter<T>(ArrayPool<T> pool = null, bool zeroOnD
     public T[] ToArray()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
+        if (segment >= 0)
+            _lengths[segment] = index;
+
         var ret = new T[AbsoluteLength];
         var offset = 0;
         for (var i = 0; i <= segment; i++)
         {
-            var seg = _segments[i];
-            var len = i == segment ? index : seg.Length;
-            seg.AsSpan(0, len).CopyTo(ret.AsSpan(offset));
+            var len = _lengths[i];
+            _segments[i].AsSpan(0, len).CopyTo(ret.AsSpan(offset));
             offset += len;
         }
         return ret;
@@ -306,10 +335,12 @@ public sealed class PooledBufferWriter<T>(ArrayPool<T> pool = null, bool zeroOnD
         foreach (var segment in _segments)
             _pool.Return(segment, zod);
         _segments.Clear();
+        _lengths.Clear();
 
         currentSegment = default;
         segment = -1;
         index = -1;
+        _priorLength = 0;
         _disposed = true;
     }
 }


### PR DESCRIPTION
## Summary

`PooledBufferWriter<T>.Grow` handled an oversized `sizeHint` mid-segment by renting a bigger array, **copying** the written portion of the current segment into it, and returning the old array to the pool. That copy existed only to preserve the invariant that every segment except the current one is fully packed.

This replaces it with **seal-and-chain**, the strategy the writer inside `System.IO.Pipelines.Pipe` uses: a segment that cannot satisfy the request is sealed where it stands and a new one is chained behind it. Committed data is never copied. The cost is the unused tail a sealed segment keeps, which is negligible next to an O(n) copy — especially for a large `sizeHint` against a mostly-full segment.

`Grow` is gone entirely; there are no `CopyTo` calls on the grow path.

## Position tracking

Because segments before the current one are no longer guaranteed packed, the position math can't derive lengths from rented capacities, so `SegmentedBufferHelpers.RelativeToAbsolute`/`AbsoluteToRelative` no longer apply here:

- A parallel `List<int> _lengths`, index-aligned with `_segments`, records each segment's actual written length, updated on seal.
- `_priorLength` keeps a running sum of the sealed prefix, so `AbsoluteLength` stays O(1) rather than walking the chain.
- `SetLength` walks `_lengths` inline. Since `length < current`, the walk provably stops at `idx <= segment`, so the subsequent indexing is always in range.
- `GetSegments()` and `ToArray()` expose only the *written* portion of each segment, not its full rented capacity.

`SegmentedBufferHelpers` is left in place — `ArrayPoolMemoryStream.Locate` still uses `AbsoluteToRelative`.

`BufferWriterBase<T>`, `SegmentedBufferWriterBase<T>` (including the inherited `Advance`), `ContiguousBufferWriterBase<T>` and `SegmentOffset<T>` are untouched.

## Behavior changes

Two visible changes, both inherent to dropping the full-packing invariant:

1. **`SegmentEnumerator.Current` is trimmed to the written length**, so a freshly chained segment with nothing written yet enumerates as a zero-length `Memory<T>`. `GetSegmentsEnumeratesEveryRentedSegment` asserted `Assert.False(Current.IsEmpty)` on exactly that segment, so it has been rewritten as `GetSegmentsEnumeratesEverySegmentTrimmedToItsWrittenLength`, asserting the per-segment written lengths instead.
2. **`GetSegments()` stops at the segment holding the write position** (`segment + 1` entries) rather than running to `_segments.Count`. Without this, `GetSegments` and `ToArray` would disagree after a `SetLength` rewind, and the enumerator would hand out stale, logically-truncated segments. `AbsoluteLength`, `ToArray` and `GetSegments` now all describe the same logical buffer.

Everything else — `Advance`, `GetMemory`, `GetSpan`, `Clear`, `Dispose`, `AbsoluteLength`, `Position`, `SetLength`, `ToArray` — keeps its existing semantics and exceptions.

## Tests

Added, covering the seal-and-chain paths:

- oversized `sizeHint` chains a new segment, renting once and returning nothing — the direct proof that the copy and the pool churn are gone
- oversized `sizeHint` moves `Position` to a new segment without inflating `AbsoluteLength`
- writes across many boundaries with varied hints (1 → 9000) round-tripping through `ToArray`
- `SetLength` rewinding into a partially-filled *sealed* segment, then resuming writes
- `GetSegments()` after such a rewind stopping at the write position
- `Clear` after sealing resetting to the first segment
- a reusable segment large enough for the request is not re-rented; one too small is returned exactly once and replaced
- `Dispose` returning every rented array exactly once after sealing (distinct-reference check)

## Verification

Not built or tested locally: this container has no .NET SDK, the environment's network policy blocks `builds.dotnet.microsoft.com`, and `LaquaiLib.UnitTests` targets `net11.0-windows` so it could not run on Linux in any case. The `.NET` workflow builds and tests on `windows-latest` with 11.0.x for PRs into `net10` — that run is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHLdxu5VCa4kr7Lx8F5PBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHLdxu5VCa4kr7Lx8F5PBD)_