### PR TITLE
Rework ArrayPoolMemoryStream sizing, SetLength growth and zeroing policy

### DIFF
--- a/TestProjects/LaquaiLib.UnitTests/IO/Streams/ArrayPoolMemoryStreamTests.cs
+++ b/TestProjects/LaquaiLib.UnitTests/IO/Streams/ArrayPoolMemoryStreamTests.cs
@@ -1,9 +1,34 @@
+using System.Buffers;
+
 using LaquaiLib.IO.Streams;
 
 namespace LaquaiLib.UnitTests.IO.Streams;
 
 public class ArrayPoolMemoryStreamTests
 {
+    // hands out exact-size arrays prefilled with a known byte, so segment layout and zeroing are observable without relying on any real pool's behaviour
+    private sealed class TrackingArrayPool(byte fill = 0) : ArrayPool<byte>
+    {
+        public List<int> RentRequests { get; } = [];
+        public List<byte[]> Rented { get; } = [];
+        public List<byte[]> Returns { get; } = [];
+
+        public override byte[] Rent(int minimumLength)
+        {
+            var array = new byte[minimumLength];
+            array.AsSpan().Fill(fill);
+            RentRequests.Add(minimumLength);
+            Rented.Add(array);
+            return array;
+        }
+        public override void Return(byte[] array, bool clearArray = false)
+        {
+            Returns.Add(array);
+            if (clearArray)
+                Array.Clear(array);
+        }
+    }
+
     private static byte[] Sequence(int length)
     {
         var data = new byte[length];
@@ -23,15 +48,10 @@ public class ArrayPoolMemoryStreamTests
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]
-    public void ConstructorRejectsNonPositiveSmallSegmentSize(int size) => Assert.Throws<ArgumentOutOfRangeException>(() => new ArrayPoolMemoryStream(size));
-
-    [Theory]
-    [InlineData(0)]
-    [InlineData(-1)]
-    public void ConstructorRejectsNonPositiveLargeSegmentSize(int size) => Assert.Throws<ArgumentOutOfRangeException>(() => new ArrayPoolMemoryStream(2048, size));
+    public void ConstructorRejectsNonPositiveMinimumSegmentSize(int size) => Assert.Throws<ArgumentOutOfRangeException>(() => new ArrayPoolMemoryStream(size));
 
     [Fact]
-    public void ConstructorRejectsNegativeCapacity() => Assert.Throws<ArgumentOutOfRangeException>(() => new ArrayPoolMemoryStream(2048, 16384, -1));
+    public void ConstructorRejectsNegativeCapacity() => Assert.Throws<ArgumentOutOfRangeException>(() => new ArrayPoolMemoryStream(2048, -1));
 
     [Fact]
     public void NewStreamIsEmpty()
@@ -78,10 +98,27 @@ public class ArrayPoolMemoryStreamTests
     }
 
     [Fact]
-    public void CapacityCoversRequestAcrossMultipleSegments()
+    public void CapacityCoversLargePreallocationRequest()
     {
-        using var stream = new ArrayPoolMemoryStream(2048, 16384, 20000);
+        using var stream = new ArrayPoolMemoryStream(2048, 20000);
         Assert.True(stream.Capacity >= 20000);
+    }
+
+    [Fact]
+    public void PreallocationAboveMinimumRentsOneSegment()
+    {
+        var pool = new TrackingArrayPool();
+        using var stream = new ArrayPoolMemoryStream(2048, 20000, pool: pool);
+        Assert.Equal(new[] { 20000 }, pool.RentRequests);
+    }
+
+    [Fact]
+    public void StreamRentsFromSuppliedPool()
+    {
+        var pool = new TrackingArrayPool();
+        using var stream = new ArrayPoolMemoryStream(pool: pool);
+        stream.WriteByte(1);
+        Assert.Single(pool.RentRequests);
     }
 
     [Fact]
@@ -270,11 +307,35 @@ public class ArrayPoolMemoryStreamTests
     }
 
     [Fact]
-    public void LargeWriteSpansMultipleSegments()
+    public void SingleWriteAboveMinimumRentsOneSegment()
     {
-        using var stream = new ArrayPoolMemoryStream(16, 32);
-        var data = Sequence(200);
+        var pool = new TrackingArrayPool();
+        using var stream = new ArrayPoolMemoryStream(16, pool: pool);
+        var data = Sequence(10000);
         stream.Write(data, 0, data.Length);
+        Assert.Equal(new[] { 10000 }, pool.RentRequests);
+    }
+
+    [Fact]
+    public void WritesBelowMinimumRentAtTheMinimumSize()
+    {
+        var pool = new TrackingArrayPool();
+        using var stream = new ArrayPoolMemoryStream(16, pool: pool);
+        for (var i = 0; i < 4; i++)
+            stream.Write(Sequence(16), 0, 16);
+        Assert.Equal(new[] { 16, 16, 16, 16 }, pool.RentRequests);
+    }
+
+    [Fact]
+    public void SuccessiveWritesSpanMultipleSegments()
+    {
+        var pool = new TrackingArrayPool();
+        using var stream = new ArrayPoolMemoryStream(16, pool: pool);
+        var data = Sequence(200);
+        for (var offset = 0; offset < data.Length; offset += 8)
+            stream.Write(data, offset, 8);
+
+        Assert.True(pool.RentRequests.Count > 1);
         Assert.Equal(200L, stream.Length);
         stream.Position = 0;
         var buffer = new byte[200];
@@ -283,15 +344,40 @@ public class ArrayPoolMemoryStreamTests
     }
 
     [Fact]
-    public void ReadAcrossSegmentBoundaryFromOffsetIsContiguous()
+    public void ReadAcrossDifferentlySizedSegmentsFromOffsetIsContiguous()
     {
-        using var stream = new ArrayPoolMemoryStream(16, 16);
-        var data = Sequence(48);
-        stream.Write(data, 0, data.Length);
+        var pool = new TrackingArrayPool();
+        using var stream = new ArrayPoolMemoryStream(16, pool: pool);
+        var data = Sequence(1048);
+        stream.Write(data, 0, 16);
+        stream.Write(data, 16, 32);
+        stream.Write(data, 48, 1000);
+        Assert.Equal(new[] { 16, 32, 1000 }, pool.RentRequests);
+
         stream.Position = 8;
-        var buffer = new byte[40];
-        Assert.Equal(40, stream.Read(buffer, 0, 40));
+        var buffer = new byte[1040];
+        Assert.Equal(1040, stream.Read(buffer, 0, 1040));
         Assert.Equal(data.AsSpan(8).ToArray(), buffer);
+    }
+
+    [Fact]
+    public void WriteAcrossDifferentlySizedSegmentsIsContiguous()
+    {
+        var pool = new TrackingArrayPool();
+        using var stream = new ArrayPoolMemoryStream(16, pool: pool);
+        stream.Write(Sequence(16), 0, 16);
+        stream.Write(Sequence(48), 0, 48);
+        Assert.Equal(new[] { 16, 48 }, pool.RentRequests);
+
+        var data = Sequence(64);
+        stream.Position = 0;
+        stream.Write(data, 0, 64);
+        Assert.Equal(new[] { 16, 48 }, pool.RentRequests);
+
+        stream.Position = 0;
+        var buffer = new byte[64];
+        Assert.Equal(64, stream.Read(buffer, 0, 64));
+        Assert.Equal(data, buffer);
     }
 
     [Fact]
@@ -355,10 +441,10 @@ public class ArrayPoolMemoryStreamTests
     }
 
     [Fact]
-    public void SetLengthCannotGrowTheStream()
+    public void SetLengthRejectsNegativeValues()
     {
         using var stream = StreamWith(1, 2, 3);
-        Assert.Throws<NotSupportedException>(() => stream.SetLength(100));
+        Assert.Throws<ArgumentOutOfRangeException>(() => stream.SetLength(-1));
     }
 
     [Fact]
@@ -369,6 +455,120 @@ public class ArrayPoolMemoryStreamTests
         stream.Position = 0;
         var buffer = new byte[5];
         Assert.Equal(2, stream.Read(buffer, 0, 5));
+    }
+
+    [Fact]
+    public void SetLengthTruncationClampsPosition()
+    {
+        using var stream = StreamWith(1, 2, 3, 4, 5);
+        stream.Position = 5;
+        stream.SetLength(2);
+        Assert.Equal(2L, stream.Position);
+    }
+
+    [Fact]
+    public void SetLengthGrowsTheStream()
+    {
+        using var stream = StreamWith(1, 2, 3);
+        stream.SetLength(10);
+        Assert.Equal(10L, stream.Length);
+    }
+
+    [Fact]
+    public void SetLengthGrowthLeavesPositionAlone()
+    {
+        using var stream = StreamWith(1, 2, 3);
+        stream.Position = 1;
+        stream.SetLength(10);
+        Assert.Equal(1L, stream.Position);
+    }
+
+    [Fact]
+    public void SetLengthGrowthBeyondCapacityRentsMoreMemory()
+    {
+        using var stream = new ArrayPoolMemoryStream(16);
+        stream.SetLength(5000);
+        Assert.Equal(5000L, stream.Length);
+        Assert.True(stream.Capacity >= 5000);
+    }
+
+    [Fact]
+    public void SetLengthGrowthExposesZeroedBytes()
+    {
+        using var stream = StreamWith(1, 2, 3);
+        stream.SetLength(6);
+        stream.Position = 0;
+        var buffer = new byte[6];
+        Assert.Equal(6, stream.Read(buffer, 0, 6));
+        Assert.Equal(new byte[] { 1, 2, 3, 0, 0, 0 }, buffer);
+    }
+
+    [Fact]
+    public void SetLengthGrowthZeroesBytesDiscardedByAnEarlierTruncation()
+    {
+        using var stream = StreamWith(1, 2, 3, 4, 5);
+        stream.SetLength(2);
+        stream.SetLength(5);
+        stream.Position = 0;
+        var buffer = new byte[5];
+        Assert.Equal(5, stream.Read(buffer, 0, 5));
+        Assert.Equal(new byte[] { 1, 2, 0, 0, 0 }, buffer);
+    }
+
+    [Fact]
+    public void SetLengthGrowthAcrossASegmentBoundaryZeroesEverythingExposed()
+    {
+        var pool = new TrackingArrayPool(0xFF);
+        using var stream = new ArrayPoolMemoryStream(16, pool: pool);
+        stream.Write(Sequence(16), 0, 16);
+        stream.SetLength(40);
+        Assert.Equal(new[] { 16, 24 }, pool.RentRequests);
+
+        stream.Position = 16;
+        var buffer = new byte[24];
+        Assert.Equal(24, stream.Read(buffer, 0, 24));
+        Assert.Equal(new byte[24], buffer);
+    }
+
+    [Fact]
+    public void SetLengthGrowthSkipsZeroingWhenAskedTo()
+    {
+        var pool = new TrackingArrayPool(0xFF);
+        using var stream = new ArrayPoolMemoryStream(64, skipZeroing: true, pool: pool);
+        stream.Write(new byte[] { 1, 2, 3 }, 0, 3);
+        stream.SetLength(8);
+        stream.Position = 0;
+        var buffer = new byte[8];
+        Assert.Equal(8, stream.Read(buffer, 0, 8));
+        Assert.Equal(new byte[] { 1, 2, 3, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }, buffer);
+    }
+
+    [Fact]
+    public void WriteAfterSeekingPastEndZeroesTheGap()
+    {
+        var pool = new TrackingArrayPool(0xFF);
+        using var stream = new ArrayPoolMemoryStream(64, pool: pool);
+        stream.Write(new byte[] { 1, 2 }, 0, 2);
+        stream.Position = 5;
+        stream.WriteByte(9);
+        stream.Position = 0;
+        var buffer = new byte[6];
+        Assert.Equal(6, stream.Read(buffer, 0, 6));
+        Assert.Equal(new byte[] { 1, 2, 0, 0, 0, 9 }, buffer);
+    }
+
+    [Fact]
+    public void WriteAfterSeekingPastEndSkipsZeroingWhenAskedTo()
+    {
+        var pool = new TrackingArrayPool(0xFF);
+        using var stream = new ArrayPoolMemoryStream(64, skipZeroing: true, pool: pool);
+        stream.Write(new byte[] { 1, 2 }, 0, 2);
+        stream.Position = 5;
+        stream.WriteByte(9);
+        stream.Position = 0;
+        var buffer = new byte[6];
+        Assert.Equal(6, stream.Read(buffer, 0, 6));
+        Assert.Equal(new byte[] { 1, 2, 0xFF, 0xFF, 0xFF, 9 }, buffer);
     }
 
     [Fact]
@@ -482,9 +682,10 @@ public class ArrayPoolMemoryStreamTests
     [Fact]
     public void ReadWriteRoundTripSurvivesInterleavedSeeks()
     {
-        using var stream = new ArrayPoolMemoryStream(32, 64);
+        using var stream = new ArrayPoolMemoryStream(32);
         var data = Sequence(150);
-        stream.Write(data, 0, data.Length);
+        for (var written = 0; written < data.Length; written += 25)
+            stream.Write(data, written, 25);
 
         for (var offset = 0; offset < data.Length; offset += 37)
         {
@@ -502,5 +703,22 @@ public class ArrayPoolMemoryStreamTests
         var stream = StreamWith(1, 2, 3);
         stream.Dispose();
         stream.Dispose();
+    }
+
+    [Fact]
+    public void DisposeReturnsEverySegmentExactlyOnce()
+    {
+        var pool = new TrackingArrayPool();
+        var stream = new ArrayPoolMemoryStream(16, pool: pool);
+        stream.Write(Sequence(16), 0, 16);
+        stream.Write(Sequence(1000), 0, 1000);
+        Assert.Equal(2, pool.Rented.Count);
+
+        stream.Dispose();
+        stream.Dispose();
+
+        Assert.Equal(pool.Rented.Count, pool.Returns.Count);
+        for (var i = 0; i < pool.Rented.Count; i++)
+            Assert.Same(pool.Rented[i], pool.Returns[i]);
     }
 }

--- a/multitarget/LaquaiLib/IO/Streams/ArrayPoolMemoryStream.cs
+++ b/multitarget/LaquaiLib/IO/Streams/ArrayPoolMemoryStream.cs
@@ -7,23 +7,30 @@ namespace LaquaiLib.IO.Streams;
 /// </summary>
 public sealed class ArrayPoolMemoryStream : Stream
 {
-    private static readonly ArrayPool<byte> _pool = ArrayPool<byte>.Shared;
-
+    private readonly ArrayPool<byte> _pool;
     private readonly List<byte[]> _segments = [];
-    private readonly int _smallSegmentSize, _largeSegmentSize;
+    private readonly int _minimumSegmentSize;
+    private readonly bool _skipZeroing;
 
     private Task<int> _lastReadTask;
     private long position, length, capacity;
     private bool _disposed;
 
-    public ArrayPoolMemoryStream(int smallSegmentSize = 2048, int largeSegmentSize = 16384, long capacity = 0)
+    /// <summary>
+    /// Initializes a new <see cref="ArrayPoolMemoryStream"/>.
+    /// </summary>
+    /// <param name="minimumSegmentSize">Smallest size any single segment will be rented at.</param>
+    /// <param name="capacity">Initial capacity to rent up front.</param>
+    /// <param name="skipZeroing">If <see langword="true"/>, memory exposed by seeking or <see cref="SetLength(long)"/> past the current length is not zeroed and may contain arbitrary prior contents. Only set this if all such memory is overwritten before being read.</param>
+    /// <param name="pool">The <see cref="ArrayPool{T}"/> to rent segments from, or <see langword="null"/> to use <see cref="ArrayPool{T}.Shared"/>.</param>
+    public ArrayPoolMemoryStream(int minimumSegmentSize = 2048, long capacity = 0, bool skipZeroing = false, ArrayPool<byte> pool = null)
     {
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(smallSegmentSize);
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(largeSegmentSize);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(minimumSegmentSize);
         ArgumentOutOfRangeException.ThrowIfNegative(capacity, nameof(capacity));
 
-        _smallSegmentSize = smallSegmentSize;
-        _largeSegmentSize = largeSegmentSize;
+        _minimumSegmentSize = minimumSegmentSize;
+        _skipZeroing = skipZeroing;
+        _pool = pool ?? ArrayPool<byte>.Shared;
 
         EnsureCapacity(capacity);
     }
@@ -55,16 +62,17 @@ public sealed class ArrayPoolMemoryStream : Stream
     [MethodImpl(MethodImplOptions.AggressiveInlining)] private Span<byte[]> SegmentsSpan() => CollectionsMarshal.AsSpan(_segments);
     [MethodImpl(MethodImplOptions.AggressiveInlining)] private (int Segment, int Offset) Locate(long absolute) => SegmentedBufferHelpers.AbsoluteToRelative<byte>(SegmentsSpan(), absolute);
 
+    // one rent covers the entire gap unless it exceeds what a single array can hold; the minimum keeps many tiny writes from degenerating into rent-per-write
     private void EnsureCapacity(long required)
     {
         while (capacity < required)
         {
-            var arr = _pool.Rent(required - capacity > _largeSegmentSize ? _largeSegmentSize : _smallSegmentSize);
+            var arr = _pool.Rent((int)long.Min(long.Max(required - capacity, _minimumSegmentSize), Array.MaxLength));
             _segments.Add(arr);
             capacity += arr.Length;
         }
     }
-    // seeking past the end leaves a gap that would otherwise expose whatever the pool handed us
+    // seeking or SetLength past the end leaves a gap that would otherwise expose whatever the pool handed us
     private void ZeroRange(long start, long count)
     {
         var segments = SegmentsSpan();
@@ -164,7 +172,7 @@ public sealed class ArrayPoolMemoryStream : Stream
 
         var end = position + buffer.Length;
         EnsureCapacity(end);
-        if (position > length)
+        if (position > length && !_skipZeroing)
             ZeroRange(length, position - length);
 
         var segments = SegmentsSpan();
@@ -282,7 +290,11 @@ public sealed class ArrayPoolMemoryStream : Stream
         ArgumentOutOfRangeException.ThrowIfNegative(value);
 
         if (value > length)
-            throw new NotSupportedException("Cannot set length beyond the current length of the stream.");
+        {
+            EnsureCapacity(value);
+            if (!_skipZeroing)
+                ZeroRange(length, value - length);
+        }
 
         length = value;
         if (position > length)


### PR DESCRIPTION
Three fixes to `ArrayPoolMemoryStream`, plus a caller-injectable pool.

## `SetLength` allows growing

It previously threw `NotSupportedException` for `value > length`, deviating from the base `Stream.SetLength` contract. It now rents what it needs and zeroes the newly exposed range, the same way `Write` already did when seeking past the end.

## Single minimum-size parameter, no ceiling

`EnsureCapacity` took a small/large size pair. Two problems with that:

- `largeSegmentSize` capped every individual rent, so a 1 MB write took ~64 segments and correspondingly longer `Locate` walks. Nothing required the cap — segments are independent, contiguity across them is never assumed, and `Locate` handles arbitrary sizes.
- A gap falling between the two sizes (10 000 bytes with the old 2048/16384 defaults) rented five small segments where one covering segment would do.

The gap is always known at the call site, so `EnsureCapacity` now rents the whole outstanding gap in one go, with `minimumSegmentSize` as a floor so many tiny writes don't degenerate into rent-per-write. A 100-byte write takes one minimum-size segment; 10 KB and 1 MB writes each take one segment. The loop only iterates when a single rent can't cover the gap.

`largeSegmentSize` is gone and `smallSegmentSize` is renamed to `minimumSegmentSize` — source-breaking for callers passing the old parameters. Nothing in the repo outside the tests constructs this type.

The rent size is clamped to `Array.MaxLength` rather than `int.MaxValue`: `required` is a `long` and nothing else bounds it, and `int.MaxValue` exceeds the maximum byte array length, so clamping there would throw instead of rolling into the next loop iteration.

## Opt-out of zeroing

Zeroing was unconditional wherever a gap got exposed without being written through. For callers that immediately overwrite everything they expose it's pure overhead, so a `skipZeroing` constructor flag now guards both call sites. `ZeroRange` itself is unchanged.

## Caller-provided pool

The pool was a `static readonly` `ArrayPool<byte>.Shared`, which left segment layout, zeroing policy and disposal untestable without depending on `Shared`'s internal behaviour. It's now an optional last constructor parameter defaulting to `Shared`, matching `PooledBufferWriter<T>`.

## Tests

The test project's existing `TrackingArrayPool` pattern is reused: an exact-size pool that records rents and returns and prefills arrays with a known byte, making layout and zeroing deterministic without any assumption about a real pool.

New coverage: `SetLength` growth (length, position, capacity, zeroed bytes, zeroing of bytes discarded by an earlier truncation, growth across a segment boundary), position clamping on truncation, both `skipZeroing` paths against their zeroing counterparts, one rent per large write, minimum-size rents for small writes, reads and writes spanning differently-sized segments, and `Dispose` returning each rented array exactly once.

Two existing tests went vacuous under the sizing change — `LargeWriteSpansMultipleSegments` and `ReadAcrossSegmentBoundaryFromOffsetIsContiguous` spanned segments only because of the old cap, and would have kept passing while testing nothing. Both were restructured to build multi-segment layouts the new way. `SetLengthCannotGrowTheStream` asserted the behaviour this PR removes and is replaced by the growth tests; `ConstructorRejectsNonPositiveLargeSegmentSize` is gone with its parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XJZ23AToaLNCFG6KVKQ4B

---
_Generated by [Claude Code](https://claude.ai/code/session_014XJZ23AToaLNCFG6KVKQ4B)_